### PR TITLE
POS output and coin locking

### DIFF
--- a/testing/coincontrol.md
+++ b/testing/coincontrol.md
@@ -75,7 +75,7 @@ daemon=1
 
 Note for the last item: the tooltip not only shows in list mode but also in tree mode.
 
-* This is verified except [input locking is not supported](https://bitcointalk.org/index.php?topic=276606.msg2958814#msg2958814) as of v0.4.
+* This item is verified except that [coin locking is not supported](https://bitcointalk.org/index.php?topic=276606.msg2958814#msg2958814) as of v0.4.
 
 >  * Context menu  
 >    Copy to clipboard (amount,label,address,transaction id,lock,unlock)


### PR DESCRIPTION
I have gone through [the announcement thread of YAC coincontrol](https://bitcointalk.org/index.php?topic=276948.msg2956447#msg2956447) and links therein and updated the report regarding two changes YAC's fork has made on the bitcoin implementation: one is about [immature POS reward](https://bitcointalk.org/index.php?topic=276948.msg2980120#msg2980120), another is about [the removal of feature related to coin locking](https://bitcointalk.org/index.php?topic=276606.msg2958814#msg2958814).
