### PR TITLE
Add ability to view transactions on blockr.io

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -242,8 +242,13 @@ bool TransactionRecord::statusUpdateNeeded()
     return status.cur_num_blocks != nBestHeight;
 }
 
-std::string TransactionRecord::getTxID()
+std::string TransactionRecord::getHash()
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return hash.ToString();
 }
 
+// Reference: https://github.com/bitcoin/bitcoin/issues/3911
+std::string TransactionRecord::getTxID()
+{
+    return getHash() + strprintf("-%03d", idx);
+}

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -118,6 +118,9 @@ public:
     /** Return the unique identifier for this transaction (part) */
     std::string getTxID();
 
+    /** Return the hash for this transaction */
+    std::string getHash();
+
     /** Update status from core wallet tx.
      */
     void updateStatus(const CWalletTx &wtx);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -566,6 +566,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return rec->credit + rec->debit;
     case TxIDRole:
         return QString::fromStdString(rec->getTxID());
+    case TxHashRole:
+        return QString::fromStdString(rec->getHash());
     case ConfirmedRole:
         // Return True if transaction counts for balance
         return rec->status.confirmed && !(rec->type == TransactionRecord::Generated &&

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -44,6 +44,8 @@ public:
         AmountRole,
         /** Unique identifier */
         TxIDRole,
+        /** Transaction Hash without vout */
+        TxHashRole,
         /** Is transaction confirmed? */
         ConfirmedRole,
         /** Formatted amount, without brackets when unconfirmed */

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -28,6 +28,8 @@
 #include <QClipboard>
 #include <QLabel>
 #include <QDateTimeEdit>
+#include <QUrl>
+#include <QDesktopServices>
 
 TransactionView::TransactionView(QWidget *parent) :
     QWidget(parent), model(0), transactionProxyModel(0),
@@ -127,6 +129,7 @@ TransactionView::TransactionView(QWidget *parent) :
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
     QAction *editLabelAction = new QAction(tr("Edit label"), this);
     QAction *showDetailsAction = new QAction(tr("Show details..."), this);
+    QAction *showTransactionAction = new QAction(tr("View on blockr.io"), this);
 
     contextMenu = new QMenu();
     contextMenu->addAction(copyAddressAction);
@@ -134,6 +137,7 @@ TransactionView::TransactionView(QWidget *parent) :
     contextMenu->addAction(copyAmountAction);
     contextMenu->addAction(editLabelAction);
     contextMenu->addAction(showDetailsAction);
+    contextMenu->addAction(showTransactionAction);
 
     // Connect actions
     connect(dateWidget, SIGNAL(activated(int)), this, SLOT(chooseDate(int)));
@@ -149,6 +153,7 @@ TransactionView::TransactionView(QWidget *parent) :
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
     connect(editLabelAction, SIGNAL(triggered()), this, SLOT(editLabel()));
     connect(showDetailsAction, SIGNAL(triggered()), this, SLOT(showDetails()));
+    connect(showTransactionAction, SIGNAL(triggered()), this, SLOT(showTransaction()));
 }
 
 void TransactionView::setModel(WalletModel *model)
@@ -369,6 +374,20 @@ void TransactionView::showDetails()
     {
         TransactionDescDialog dlg(selection.at(0));
         dlg.exec();
+    }
+}
+
+void TransactionView::showTransaction()
+{
+    if(!transactionView->selectionModel())
+        return;
+    QModelIndexList selection = transactionView->selectionModel()->selectedRows();
+    if(!selection.isEmpty())
+    {
+        // TODO: Prefix with "t" if blockr adds ppc testnet support
+        QString blockr = "http://ppc.blockr.io/tx/info/";
+        QString tx = selection.at(0).data(TransactionTableModel::TxHashRole).toString();
+        QDesktopServices::openUrl(QUrl(blockr + tx));
     }
 }
 

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -65,6 +65,7 @@ private slots:
     void editLabel();
     void copyLabel();
     void copyAmount();
+    void showTransaction();
 
 signals:
     void doubleClicked(const QModelIndex&);


### PR DESCRIPTION
This adds a new TransactionRecord.getHash() method that does not
include the vout specifics included by getTxID().
