### PR TITLE
Fix bug requiring software restart to display new stake

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -14,7 +14,7 @@
 WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),
-    cachedBalance(0), cachedUnconfirmedBalance(0), cachedNumTransactions(0),
+    cachedBalance(0), cachedStake(0), cachedUnconfirmedBalance(0), cachedNumTransactions(0),
     cachedEncryptionStatus(Unencrypted)
 {
     addressTableModel = new AddressTableModel(wallet, this);
@@ -29,6 +29,11 @@ qint64 WalletModel::getBalance() const
 qint64 WalletModel::getStake() const
 {
     return wallet->GetStake();
+}
+
+qint64 WalletModel::getNewMint() const
+{
+    return wallet->GetNewMint();
 }
 
 qint64 WalletModel::getUnconfirmedBalance() const
@@ -49,12 +54,13 @@ int WalletModel::getNumTransactions() const
 void WalletModel::update()
 {
     qint64 newBalance = getBalance();
-    qint64 newUnconfirmedBalance = getUnconfirmedBalance();
+    qint64 newStake = getStake();
+    qint64 newUnconfirmedBalance = getUnconfirmedBalance() + getNewMint();
     int newNumTransactions = getNumTransactions();
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
-    if(cachedBalance != newBalance || cachedUnconfirmedBalance != newUnconfirmedBalance)
-        emit balanceChanged(newBalance, getStake(), newUnconfirmedBalance);
+    if(cachedBalance != newBalance || cachedStake != newStake || cachedUnconfirmedBalance != newUnconfirmedBalance)
+        emit balanceChanged(newBalance, newStake, newUnconfirmedBalance);
 
     if(cachedNumTransactions != newNumTransactions)
         emit numTransactionsChanged(newNumTransactions);
@@ -63,6 +69,7 @@ void WalletModel::update()
         emit encryptionStatusChanged(newEncryptionStatus);
 
     cachedBalance = newBalance;
+    cachedStake = newStake;
     cachedUnconfirmedBalance = newUnconfirmedBalance;
     cachedNumTransactions = newNumTransactions;
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -59,6 +59,7 @@ public:
 
     qint64 getBalance() const;
     qint64 getStake() const;
+    qint64 getNewMint() const;
     qint64 getUnconfirmedBalance() const;
     int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
@@ -132,6 +133,7 @@ private:
 
     // Cache some values to be able to detect changes
     qint64 cachedBalance;
+    qint64 cachedStake;
     qint64 cachedUnconfirmedBalance;
     qint64 cachedNumTransactions;
     EncryptionStatus cachedEncryptionStatus;


### PR DESCRIPTION
I tried to fix the bug preventing the stake from being displayed in the overview tab of the GUI when minting a block (restart needed to see it).

However, I wasn't able to test it because my testnet coins aren't old enough to mint, and I don't know if some of my real coins will mint any time soon...

Maybe one of you has old enough testnet coins and could give it a try ?
