### PR TITLE
Update transaction fee text in the "options" dialog

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -214,15 +214,16 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     proxy_hbox->addStretch(1);
 
     layout->addLayout(proxy_hbox);
-    QLabel *fee_help = new QLabel(tr("Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB. Fee 0.01 recommended."));
+    QLabel *fee_help = new QLabel(tr("Mandatory network transaction fee per kB transferred. Most transactions are 1 kB and incur a 0.01 PPC fee. Note: transfer size may increase depending on the number of input transactions required to be added together to fund the payment."));
     fee_help->setWordWrap(true);
     layout->addWidget(fee_help);
 
     QHBoxLayout *fee_hbox = new QHBoxLayout();
     fee_hbox->addSpacing(18);
-    QLabel *fee_label = new QLabel(tr("Pay transaction &fee"));
+    QLabel *fee_label = new QLabel(tr("Additional network &fee:"));
     fee_hbox->addWidget(fee_label);
     fee_edit = new BitcoinAmountField();
+    fee_edit->setDisabled(true);
 
     fee_label->setBuddy(fee_edit);
     fee_hbox->addWidget(fee_edit);


### PR DESCRIPTION
Update options dialog text with content that refers to the transaction fee as mandatory, vs. optional as it appears in PPCoin-Qt (reference, v0.4).
