### PR TITLE
Don't test the software version when opening a wallet

### DIFF
--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -117,13 +117,13 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
     //// todo: shouldn't we catch exceptions and try to recover and continue?
     {
         LOCK(pwallet->cs_wallet);
-        int nMinVersion = 0;
-        if (Read((string)"minversion", nMinVersion))
-        {
-            if (nMinVersion > CLIENT_VERSION)
-                return DB_TOO_NEW;
-            pwallet->LoadMinVersion(nMinVersion);
-        }
+        // int nMinVersion = 0;
+        // if (Read((string)"minversion", nMinVersion))
+        // {
+        //     if (nMinVersion > CLIENT_VERSION)
+        //         return DB_TOO_NEW;
+        //     pwallet->LoadMinVersion(nMinVersion);
+        // }
 
         // Get cursor
         Dbc* pcursor = GetCursor();


### PR DESCRIPTION
Not doing the "minversion" test allows to open a wallet last used with ppcoin-qt 0.4.0 with Peerunity 0.1.0 (issue #61).

For the moment, the code for this test is commented out (and not deleted).
