### PR TITLE
CLIENT_VERSION fix

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -19,17 +19,6 @@
 #define PEERUNITY_VERSION_REVISION    0
 #define PEERUNITY_VERSION_BUILD       0
 
-static const int CLIENT_VERSION =
-                           1000000 * PEERUNITY_VERSION_MAJOR
-                         +   10000 * PEERUNITY_VERSION_MINOR 
-                         +     100 * PEERUNITY_VERSION_REVISION
-                         +       1 * PEERUNITY_VERSION_BUILD;
-
-extern const std::string CLIENT_NAME;
-extern const std::string CLIENT_BUILD;
-extern const std::string CLIENT_DATE;
-
-
 // ppcoin version - reference for code tracking
 #define PPCOIN_VERSION_MAJOR       0
 #define PPCOIN_VERSION_MINOR       4
@@ -53,6 +42,13 @@ static const int BITCOIN_VERSION =
                          +   10000 * BITCOIN_VERSION_MINOR 
                          +     100 * BITCOIN_VERSION_REVISION
                          +       1 * BITCOIN_VERSION_BUILD;
+
+static const int CLIENT_VERSION = BITCOIN_VERSION;
+
+extern const std::string CLIENT_NAME;
+extern const std::string CLIENT_BUILD;
+extern const std::string CLIENT_DATE;
+
 
 //
 // network protocol versioning


### PR DESCRIPTION
To fix Peerunity#61

`CLIENT_VERSION` is used at many places so it should be the same as Peercoin's (0.6.3.0).
