### PR TITLE
Added Peerunity version to the "user agent" string

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1117,6 +1117,8 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
         ss << "(" << boost::algorithm::join(comments, "; ") << ")";
     ss << "/";
     ss << "Peercoin:" << FormatVersion(PPCOIN_VERSION);
+    ss << "/";
+    ss << "Peerunity:" << FormatVersion(PEERUNITY_VERSION);
     ss << "(" << CLIENT_BUILD << ")/";
     return ss.str();
 }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -14,9 +14,7 @@
 // the list of ancient coinage, from oldest known to more recent. 
 // You can find ideas for future client names, here: http://en.wikipedia.org/wiki/List_of_historical_currencies
 
-// Version 0.1.0 is named for the Lydian stater, an electrum coin
-// Reference: http://www.fleur-de-coin.com/articles/oldest-coin
-const std::string CLIENT_NAME("Stater");
+const std::string CLIENT_NAME("Satoshi");
 
 // Client version number
 #define CLIENT_VERSION_SUFFIX   ""

--- a/src/version.h
+++ b/src/version.h
@@ -19,6 +19,12 @@
 #define PEERUNITY_VERSION_REVISION    0
 #define PEERUNITY_VERSION_BUILD       0
 
+static const int PEERUNITY_VERSION =
+                           1000000 * PEERUNITY_VERSION_MAJOR
+                         +   10000 * PEERUNITY_VERSION_MINOR
+                         +     100 * PEERUNITY_VERSION_REVISION
+                         +       1 * PEERUNITY_VERSION_BUILD;
+
 // ppcoin version - reference for code tracking
 #define PPCOIN_VERSION_MAJOR       0
 #define PPCOIN_VERSION_MINOR       4


### PR DESCRIPTION
See Peerunity#64.

I reverted the change on `CLIENT_NAME` to switch the first string back to "Satoshi".

I think this constant is not the right place to put a version name.
