### PR TITLE
Display the transaction time instead of the reception time.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -494,7 +494,7 @@ bool CWallet::IsChange(const CTxOut& txout) const
 
 int64 CWalletTx::GetTxTime() const
 {
-    return nTimeReceived;
+    return nTime;
 }
 
 int CWalletTx::GetRequestCount() const


### PR DESCRIPTION
For issue #128.
