### PR TITLE
Fixed change when avatar mode is enabled

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1192,18 +1192,13 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
 
                 if (nChange > 0)
                 {
-                    if (!GetBoolArg("-avatar")) // ppcoin: not avatar mode
+                    // coin control: send change to custom address
+                    if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
+                        scriptChange.SetDestination(coinControl->destChange);
+                    else
                     {
-                        // Fill a vout to ourself
-                        // TODO: pass in scriptChange instead of reservekey so
-                        // change transaction isn't always pay-to-bitcoin-address
-
-                        // coin control: send change to custom address
-                        if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
-                            scriptChange.SetDestination(coinControl->destChange);
-                        
-                        // no coin control: send change to newly generated address
-                        else
+                        // no coin control: send change to newly generated address unless avatar mode is enabled
+                        if (!GetBoolArg("-avatar")) // ppcoin: not avatar mode
                         {
                             // Note: We use a new key here to keep it from being obvious which side is the change.
                             //  The drawback is that by not reusing a previous key, the change may be lost if a


### PR DESCRIPTION
If avatar mode is enabled, the change is lost (it's not sent at all, so it's lost as excess fees). This pull request fixes that.

I haven't taken time to test that. It'd be nice if some people could confirm on testnet that the change is correctly sent in these situations combined in all possible ways:
- coin control activated or not
- coins sent with an explicit change address defined in coin control or not
- avatar mode enabled or not

**In the meantime avatar mode must absolutely be disabled when using Peerunity** (it's disabled by default).
