### PR TITLE
Add multisig dialog.

### DIFF
--- a/peerunity.pro
+++ b/peerunity.pro
@@ -173,7 +173,10 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/mintingtablemodel.h \
     src/qt/mintingfilterproxy.h \
     src/kernelrecord.h \
-    src/qt/virtualkeyboard.h
+    src/qt/virtualkeyboard.h \
+    src/qt/multisigaddressentry.h \
+    src/qt/multisiginputentry.h \
+    src/qt/multisigdialog.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \
@@ -236,7 +239,10 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/mintingtablemodel.cpp \
     src/qt/mintingfilterproxy.cpp \
     src/kernelrecord.cpp \
-    src/qt/virtualkeyboard.cpp
+    src/qt/virtualkeyboard.cpp \
+    src/qt/multisigaddressentry.cpp \
+    src/qt/multisiginputentry.cpp \
+    src/qt/multisigdialog.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc
@@ -252,7 +258,10 @@ FORMS += \
     src/qt/forms/overviewpage.ui \
     src/qt/forms/sendcoinsentry.ui \
     src/qt/forms/askpassphrasedialog.ui \
-    src/qt/forms/rpcconsole.ui
+    src/qt/forms/rpcconsole.ui \
+    src/qt/forms/multisigaddressentry.ui \
+    src/qt/forms/multisiginputentry.ui \
+    src/qt/forms/multisigdialog.ui
 
 contains(USE_QRCODE, 1) {
 HEADERS += src/qt/qrcodedialog.h

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -10,6 +10,7 @@
 #include "addressbookpage.h"
 #include "sendcoinsdialog.h"
 #include "signverifymessagedialog.h"
+#include "multisigdialog.h"
 #include "optionsdialog.h"
 #include "aboutdialog.h"
 #include "clientmodel.h"
@@ -117,6 +118,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     sendCoinsPage = new SendCoinsDialog(this);
 
     messagePage = new SignVerifyMessageDialog(this);
+
+    multisigPage = new MultisigDialog(this);
 
     centralWidget = new QStackedWidget(this);
     centralWidget->addWidget(overviewPage);
@@ -231,6 +234,9 @@ void BitcoinGUI::createActions()
 #endif
     tabGroup->addAction(messageAction);
 
+    multisigAction = new QAction(QIcon(":/icons/send"), tr("Multisig"), this);
+    tabGroup->addAction(multisigAction);
+
     connect(overviewAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(overviewAction, SIGNAL(triggered()), this, SLOT(gotoOverviewPage()));
     connect(historyAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
@@ -245,6 +251,8 @@ void BitcoinGUI::createActions()
     connect(sendCoinsAction, SIGNAL(triggered()), this, SLOT(gotoSendCoinsPage()));
     connect(messageAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(messageAction, SIGNAL(triggered()), this, SLOT(gotoMessagePage()));
+    connect(multisigAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
+    connect(multisigAction, SIGNAL(triggered()), this, SLOT(gotoMultisigPage()));
 
     quitAction = new QAction(QIcon(":/icons/quit"), tr("E&xit"), this);
     quitAction->setToolTip(tr("Quit application"));
@@ -304,6 +312,7 @@ void BitcoinGUI::createMenuBar()
 #ifndef FIRST_CLASS_MESSAGING
     file->addAction(messageAction);
 #endif
+    file->addAction(multisigAction);
     file->addSeparator();
     file->addAction(quitAction);
 
@@ -392,6 +401,7 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
         receiveCoinsPage->setModel(walletModel->getAddressTableModel());
         sendCoinsPage->setModel(walletModel);
         messagePage->setModel(walletModel);
+        multisigPage->setModel(walletModel);
 
         setEncryptionStatus(walletModel->getEncryptionStatus());
         connect(walletModel, SIGNAL(encryptionStatusChanged(int)), this, SLOT(setEncryptionStatus(int)));
@@ -433,6 +443,7 @@ void BitcoinGUI::createTrayIcon()
 #endif
     trayIconMenu->addAction(receiveCoinsAction);
     trayIconMenu->addAction(sendCoinsAction);
+    trayIconMenu->addAction(multisigAction);
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
 #ifndef Q_WS_MAC // This is built-in on Mac
@@ -768,6 +779,12 @@ void BitcoinGUI::gotoMessagePage()
     messagePage->show();
     messagePage->setFocus();
 #endif
+}
+
+void BitcoinGUI::gotoMultisigPage()
+{
+    multisigPage->show();
+    multisigPage->setFocus();
 }
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -13,6 +13,7 @@ class OverviewPage;
 class AddressBookPage;
 class SendCoinsDialog;
 class SignVerifyMessageDialog;
+class MultisigDialog;
 class Notificator;
 class RPCConsole;
 
@@ -67,6 +68,7 @@ private:
     AddressBookPage *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
     SignVerifyMessageDialog *messagePage;
+    MultisigDialog *multisigPage;
 
     QLabel *labelEncryptionIcon;
     QLabel *labelConnectionsIcon;
@@ -82,6 +84,7 @@ private:
     QAction *sendCoinsAction;
     QAction *addressBookAction;
     QAction *messageAction;
+    QAction *multisigAction;
     QAction *aboutAction;
     QAction *receiveCoinsAction;
     QAction *optionsAction;
@@ -136,6 +139,7 @@ public slots:
     void handleURI(QString strURI);
 
     void gotoMessagePage();
+    void gotoMultisigPage();
 
 private slots:
     /** Switch to overview (home) page */

--- a/src/qt/forms/multisigaddressentry.ui
+++ b/src/qt/forms/multisigaddressentry.ui
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MultisigAddressEntry</class>
+ <widget class="QFrame" name="MultisigAddressEntry">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>729</width>
+    <height>136</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="frameShape">
+   <enum>QFrame::StyledPanel</enum>
+  </property>
+  <property name="frameShadow">
+   <enum>QFrame::Sunken</enum>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="pubkeyLabel">
+     <property name="text">
+      <string>Public &amp;key:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>pubkey</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="pubkeyLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QValidatedLineEdit" name="pubkey">
+       <property name="toolTip">
+        <string>The public key of an address</string>
+       </property>
+       <property name="placeholderText">
+        <string>Enter a public key</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pasteButton">
+       <property name="toolTip">
+        <string>Paste public key from clipboard</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
+       </property>
+       <property name="shortcut">
+        <string>Alt+P</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="deleteButton">
+       <property name="toolTip">
+        <string>Remove this public key</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="addressLabel">
+     <property name="text">
+      <string>&amp;Address:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>address</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="addressLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QValidatedLineEdit" name="address">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Address associated to the public key</string>
+       </property>
+       <property name="placeholderText">
+        <string>Enter one of your addresses to get its public key</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="addressBookButton">
+       <property name="toolTip">
+        <string>Choose address from address book</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/address-book</normaloff>:/icons/address-book</iconset>
+       </property>
+       <property name="shortcut">
+        <string>Alt+A</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelLabel">
+     <property name="text">
+      <string>Label:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QValidatedLineEdit" name="label">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Address associated to the public key</string>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/multisigdialog.ui
+++ b/src/qt/forms/multisigdialog.ui
@@ -1,0 +1,793 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MultisigDialog</class>
+ <widget class="QDialog" name="MultisigDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1327</width>
+    <height>595</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Multisig</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tabCreateAddress">
+      <attribute name="title">
+       <string>&amp;Create Address</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1283</width>
+            <height>310</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <layout class="QVBoxLayout" name="pubkeyEntries"/>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_14">
+         <item>
+          <widget class="QPushButton" name="addPubKeyButton">
+           <property name="toolTip">
+            <string>Add a member to the signing pool</string>
+           </property>
+           <property name="text">
+            <string>&amp;Add public key...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../bitcoin.qrc">
+             <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clearButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Remove all public key fields</string>
+           </property>
+           <property name="text">
+            <string>Clear all</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../bitcoin.qrc">
+             <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+           </property>
+           <property name="autoRepeatDelay">
+            <number>300</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="requiredSignaturesLabel">
+           <property name="text">
+            <string>Required signatures:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="requiredSignatures">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>127</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="maxLength">
+            <number>2</number>
+           </property>
+           <property name="frame">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="placeholderText">
+            <string>Enter a number</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="maxSignaturesLabel">
+           <property name="text">
+            <string>/ 1</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="createAddressButton">
+           <property name="text">
+            <string>Create multisig address</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutMultisigAddress">
+         <item>
+          <widget class="QLabel" name="multisigAddressLabel">
+           <property name="text">
+            <string>Multisig address:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="multisigAddress">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="copyMultisigAddressButton">
+           <property name="toolTip">
+            <string>Copy the multisig address to the system clipboard</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../bitcoin.qrc">
+             <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="redeemScriptLabel">
+           <property name="text">
+            <string>Redeem script:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="redeemScript">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="copyRedeemScriptButton">
+           <property name="toolTip">
+            <string>Copy the redeem script to the system clipboard</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../bitcoin.qrc">
+             <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="saveRedeemScriptButton">
+           <property name="toolTip">
+            <string>The redeem script will be required to spend the funds sent to the multisig address</string>
+           </property>
+           <property name="text">
+            <string>Save redeem script</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="saveMultisigAddressButton">
+           <property name="toolTip">
+            <string>Add the multisig address to your personal addresses</string>
+           </property>
+           <property name="text">
+            <string>Add address to wallet</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabSpendFunds">
+      <attribute name="title">
+       <string>&amp;Spend Funds</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_13">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_8">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QGroupBox" name="inputsBox">
+             <property name="title">
+              <string>Inputs</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_6">
+              <item>
+               <widget class="QScrollArea" name="scrollArea_2">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="widgetResizable">
+                 <bool>true</bool>
+                </property>
+                <widget class="QWidget" name="scrollAreaWidgetContents_2">
+                 <property name="geometry">
+                  <rect>
+                   <x>0</x>
+                   <y>0</y>
+                   <width>613</width>
+                   <height>221</height>
+                  </rect>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_4">
+                  <item>
+                   <layout class="QVBoxLayout" name="inputs"/>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_2">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>42</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <item>
+                 <spacer name="horizontalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="inputsAmountLabel">
+                  <property name="text">
+                   <string>Inputs amount:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="inputsAmount">
+                  <property name="text">
+                   <string>123.456</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>PPC</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QPushButton" name="addInputButton">
+                  <property name="text">
+                   <string>Add input...</string>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="../bitcoin.qrc">
+                    <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="outputsBox">
+             <property name="title">
+              <string>Outputs</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_7">
+              <item>
+               <widget class="QScrollArea" name="scrollArea_3">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="widgetResizable">
+                 <bool>true</bool>
+                </property>
+                <widget class="QWidget" name="scrollAreaWidgetContents_3">
+                 <property name="geometry">
+                  <rect>
+                   <x>0</x>
+                   <y>0</y>
+                   <width>612</width>
+                   <height>193</height>
+                  </rect>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_5">
+                  <item>
+                   <layout class="QVBoxLayout" name="outputs"/>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_3">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>42</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <spacer name="horizontalSpacer_10">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="outputsAmountLabel">
+                  <property name="text">
+                   <string>Outputs amount:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="outputsAmount">
+                  <property name="text">
+                   <string>123.456</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_2">
+                  <property name="text">
+                   <string>PPC</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_16">
+                <item>
+                 <spacer name="horizontalSpacer_12">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="feeLabel">
+                  <property name="text">
+                   <string>Fee:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="fee">
+                  <property name="text">
+                   <string>123.456</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="text">
+                   <string>PPC</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <item>
+                 <widget class="QPushButton" name="addOutputButton">
+                  <property name="text">
+                   <string>Add output...</string>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="../bitcoin.qrc">
+                    <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <item>
+            <widget class="QPushButton" name="createTransactionButton">
+             <property name="text">
+              <string>Create transaction</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_10">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_10">
+           <item>
+            <widget class="QLineEdit" name="transaction">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="placeholderText">
+              <string>Enter a raw transaction or create a new one</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="copyTransactionButton">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pasteTransactionButton">
+             <property name="toolTip">
+              <string>Paste address from clipboard</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
+             </property>
+             <property name="shortcut">
+              <string>Alt+P</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+           <item>
+            <widget class="QPushButton" name="signTransactionButton">
+             <property name="text">
+              <string>Sign transaction</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_12">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_13">
+           <item>
+            <widget class="QLineEdit" name="signedTransaction">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="copySignedTransactionButton">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_12">
+           <item>
+            <widget class="QLabel" name="statusLabel">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sendTransactionButton">
+             <property name="text">
+              <string>Send transaction</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/multisiginputentry.ui
+++ b/src/qt/forms/multisiginputentry.ui
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MultisigInputEntry</class>
+ <widget class="QFrame" name="MultisigInputEntry">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>729</width>
+    <height>136</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="frameShape">
+   <enum>QFrame::StyledPanel</enum>
+  </property>
+  <property name="frameShadow">
+   <enum>QFrame::Sunken</enum>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="transactionIdLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QValidatedLineEdit" name="transactionId">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="placeholderText">
+        <string>Enter a transaction id</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pasteTransactionIdButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
+       </property>
+       <property name="shortcut">
+        <string>Alt+P</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="deleteButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="transactionIdLabel">
+     <property name="text">
+      <string>Transaction id:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>transactionId</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="transactionOutputLabel">
+     <property name="text">
+      <string>Transaction output:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="redeemScriptLabel">
+     <property name="text">
+      <string>Redeem script:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>redeemScript</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="redeemScriptLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QValidatedLineEdit" name="redeemScript">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="placeholderText">
+        <string>Enter the redeem script of the address in the transaction output</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pasteRedeemScriptButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
+       </property>
+       <property name="shortcut">
+        <string>Alt+A</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="transactionOutput"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/multisigaddressentry.cpp
+++ b/src/qt/multisigaddressentry.cpp
@@ -1,0 +1,118 @@
+#include <QApplication>
+#include <QClipboard>
+#include <string>
+#include <vector>
+
+#include "addressbookpage.h"
+#include "addresstablemodel.h"
+#include "base58.h"
+#include "guiutil.h"
+#include "key.h"
+#include "multisigaddressentry.h"
+#include "ui_multisigaddressentry.h"
+#include "walletmodel.h"
+
+
+MultisigAddressEntry::MultisigAddressEntry(QWidget *parent) : QFrame(parent), ui(new Ui::MultisigAddressEntry), model(0)
+{
+    ui->setupUi(this);
+    GUIUtil::setupAddressWidget(ui->address, this);
+}
+
+MultisigAddressEntry::~MultisigAddressEntry()
+{
+    delete ui;
+}
+
+void MultisigAddressEntry::setModel(WalletModel *model)
+{
+    this->model = model;
+    clear();
+}
+
+void MultisigAddressEntry::clear()
+{
+    ui->pubkey->clear();
+    ui->address->clear();
+    ui->label->clear();
+    ui->pubkey->setFocus();
+}
+
+bool MultisigAddressEntry::validate()
+{
+    return !ui->pubkey->text().isEmpty();
+}
+
+QString MultisigAddressEntry::getPubkey()
+{
+    return ui->pubkey->text();
+}
+
+void MultisigAddressEntry::setRemoveEnabled(bool enabled)
+{
+    ui->deleteButton->setEnabled(enabled);
+}
+
+void MultisigAddressEntry::on_pasteButton_clicked()
+{
+    ui->address->setText(QApplication::clipboard()->text());
+}
+
+void MultisigAddressEntry::on_deleteButton_clicked()
+{
+    emit removeEntry(this);
+}
+
+void MultisigAddressEntry::on_addressBookButton_clicked()
+{
+    if(!model)
+        return;
+
+    AddressBookPage dlg(AddressBookPage::ForSending, AddressBookPage::ReceivingTab, this);
+    dlg.setModel(model->getAddressTableModel());
+    if(dlg.exec())
+    {
+        ui->address->setText(dlg.getReturnValue());
+    }
+}
+
+void MultisigAddressEntry::on_pubkey_textChanged(const QString &pubkey)
+{
+    // Compute address from public key
+    std::vector<unsigned char> vchPubKey(ParseHex(pubkey.toStdString().c_str()));
+    CPubKey pkey(vchPubKey);
+    CKeyID keyID = pkey.GetID();
+    CBitcoinAddress address(keyID);
+    ui->address->setText(address.ToString().c_str());
+
+    if(!model)
+        return;
+
+    // Get label of address
+    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address.ToString().c_str());
+    if(!associatedLabel.isEmpty())
+        ui->label->setText(associatedLabel);
+}
+
+void MultisigAddressEntry::on_address_textChanged(const QString &address)
+{
+    if(!model)
+        return;
+
+    // Get public key of address
+    CBitcoinAddress addr(address.toStdString().c_str());
+    CKeyID keyID;
+    if(addr.GetKeyID(keyID))
+    {
+        CPubKey vchPubKey;
+        model->getPubKey(keyID, vchPubKey);
+        std::string pubkey = HexStr(vchPubKey.Raw());
+        if(!pubkey.empty())
+            ui->pubkey->setText(pubkey.c_str());
+    }
+
+    // Get label of address
+    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
+    if(!associatedLabel.isEmpty())
+        ui->label->setText(associatedLabel);
+}

--- a/src/qt/multisigaddressentry.h
+++ b/src/qt/multisigaddressentry.h
@@ -1,0 +1,44 @@
+#ifndef MULTISIGADDRESSENTRY_H
+#define MULTISIGADDRESSENTRY_H
+
+#include <QFrame>
+
+
+class WalletModel;
+
+namespace Ui
+{
+    class MultisigAddressEntry;
+}
+
+class MultisigAddressEntry : public QFrame
+{
+    Q_OBJECT;
+
+  public:
+    explicit MultisigAddressEntry(QWidget *parent = 0);
+    ~MultisigAddressEntry();
+    void setModel(WalletModel *model);
+    bool validate();
+    QString getPubkey();
+
+  public slots:
+    void setRemoveEnabled(bool enabled);
+    void clear();
+
+  signals:
+    void removeEntry(MultisigAddressEntry *entry);
+
+  private:
+    Ui::MultisigAddressEntry *ui;
+    WalletModel *model;
+
+  private slots:
+    void on_pubkey_textChanged(const QString &pubkey);
+    void on_pasteButton_clicked();
+    void on_deleteButton_clicked();
+    void on_address_textChanged(const QString &address);
+    void on_addressBookButton_clicked();
+};
+
+#endif // MULTISIGADDRESSENTRY_H

--- a/src/qt/multisigdialog.cpp
+++ b/src/qt/multisigdialog.cpp
@@ -1,0 +1,595 @@
+#include <QClipboard>
+#include <QDialog>
+#include <QMessageBox>
+#include <QScrollBar>
+#include <vector>
+
+#include "addresstablemodel.h"
+#include "base58.h"
+#include "key.h"
+#include "main.h"
+#include "multisigaddressentry.h"
+#include "multisiginputentry.h"
+#include "multisigdialog.h"
+#include "ui_multisigdialog.h"
+#include "script.h"
+#include "sendcoinsentry.h"
+#include "util.h"
+#include "wallet.h"
+#include "walletmodel.h"
+
+
+MultisigDialog::MultisigDialog(QWidget *parent) : QDialog(parent), ui(new Ui::MultisigDialog), model(0)
+{
+    ui->setupUi(this);
+
+#ifdef Q_WS_MAC // Icons on push buttons are very uncommon on Mac
+    ui->addPubKeyButton->setIcon(QIcon());
+    ui->clearButton->setIcon(QIcon());
+    ui->addInputButton->setIcon(QIcon());
+    ui->addOutputButton->setIcon(QIcon());
+    ui->signTransactionButton->setIcon(QIcon());
+    ui->sendTransactionButton->setIcon(QIcon());
+#endif
+
+    addPubKey();
+    addPubKey();
+
+    connect(ui->addPubKeyButton, SIGNAL(clicked()), this, SLOT(addPubKey()));
+    connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+
+    addInput();
+    addOutput();
+    updateAmounts();
+
+    connect(ui->addInputButton, SIGNAL(clicked()), this, SLOT(addInput()));
+    connect(ui->addOutputButton, SIGNAL(clicked()), this, SLOT(addOutput()));
+
+    ui->signTransactionButton->setEnabled(false);
+    ui->sendTransactionButton->setEnabled(false);
+}
+
+MultisigDialog::~MultisigDialog()
+{
+    delete ui;
+}
+
+void MultisigDialog::setModel(WalletModel *model)
+{
+    this->model = model;
+
+    for(int i = 0; i < ui->pubkeyEntries->count(); i++)
+    {
+        MultisigAddressEntry *entry = qobject_cast<MultisigAddressEntry *>(ui->pubkeyEntries->itemAt(i)->widget());
+        if(entry)
+            entry->setModel(model);
+    }
+
+
+    for(int i = 0; i < ui->inputs->count(); i++)
+    {
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(i)->widget());
+        if(entry)
+            entry->setModel(model);
+    }
+
+
+    for(int i = 0; i < ui->outputs->count(); i++)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->outputs->itemAt(i)->widget());
+        if(entry)
+            entry->setModel(model);
+    }
+}
+
+void MultisigDialog::updateRemoveEnabled()
+{
+    bool enabled = (ui->pubkeyEntries->count() > 2);
+
+    for(int i = 0; i < ui->pubkeyEntries->count(); i++)
+    {
+        MultisigAddressEntry *entry = qobject_cast<MultisigAddressEntry *>(ui->pubkeyEntries->itemAt(i)->widget());
+        if(entry)
+            entry->setRemoveEnabled(enabled);
+    }
+
+    QString maxSigsStr;
+    maxSigsStr.setNum(ui->pubkeyEntries->count());
+    ui->maxSignaturesLabel->setText(QString("/ ") + maxSigsStr);
+
+
+    enabled = (ui->inputs->count() > 1);
+    for(int i = 0; i < ui->inputs->count(); i++)
+    {
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(i)->widget());
+        if(entry)
+            entry->setRemoveEnabled(enabled);
+    }
+
+
+    enabled = (ui->outputs->count() > 1);
+    for(int i = 0; i < ui->outputs->count(); i++)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->outputs->itemAt(i)->widget());
+        if(entry)
+            entry->setRemoveEnabled(enabled);
+    }
+}
+
+void MultisigDialog::on_createAddressButton_clicked()
+{
+    ui->multisigAddress->clear();
+    ui->redeemScript->clear();
+
+    if(!model)
+        return;
+
+    std::vector<CPubKey> pubkeys;
+    unsigned int required = ui->requiredSignatures->text().toUInt();
+
+    for(int i = 0; i < ui->pubkeyEntries->count(); i++)
+    {
+        MultisigAddressEntry *entry = qobject_cast<MultisigAddressEntry *>(ui->pubkeyEntries->itemAt(i)->widget());
+        if(!entry->validate())
+            return;
+        QString str = entry->getPubkey();
+        CPubKey vchPubKey(ParseHex(str.toStdString().c_str()));
+        if(!vchPubKey.IsFullyValid())
+            return;
+        pubkeys.push_back(vchPubKey);
+    }
+
+    if((required == 0) || (required > pubkeys.size()))
+       return;
+
+    CScript script;
+    script.SetMultisig(required, pubkeys);
+    CScriptID scriptID = script.GetID();
+    CBitcoinAddress address(scriptID);
+
+    ui->multisigAddress->setText(address.ToString().c_str());
+    ui->redeemScript->setText(HexStr(script.begin(), script.end()).c_str());
+}
+
+void MultisigDialog::on_copyMultisigAddressButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->multisigAddress->text());
+}
+
+void MultisigDialog::on_copyRedeemScriptButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->redeemScript->text());
+}
+
+void MultisigDialog::on_saveRedeemScriptButton_clicked()
+{
+    if(!model)
+        return;
+
+    CWallet *wallet = model->getWallet();
+    std::string redeemScript = ui->redeemScript->text().toStdString();
+    std::vector<unsigned char> scriptData(ParseHex(redeemScript));
+    CScript script(scriptData.begin(), scriptData.end());
+    CScriptID scriptID = script.GetID();
+
+    LOCK(wallet->cs_wallet);
+    if(!wallet->HaveCScript(scriptID))
+        wallet->AddCScript(script);
+}
+
+void MultisigDialog::on_saveMultisigAddressButton_clicked()
+{
+    if(!model)
+        return;
+
+    CWallet *wallet = model->getWallet();
+    std::string redeemScript = ui->redeemScript->text().toStdString();
+    std::string address = ui->multisigAddress->text().toStdString();
+    std::string label("multisig");
+
+    if(!model->validateAddress(QString(address.c_str())))
+        return;
+
+    std::vector<unsigned char> scriptData(ParseHex(redeemScript));
+    CScript script(scriptData.begin(), scriptData.end());
+    CScriptID scriptID = script.GetID();
+
+    LOCK(wallet->cs_wallet);
+    if(!wallet->HaveCScript(scriptID))
+        wallet->AddCScript(script);
+    if(!wallet->mapAddressBook.count(CBitcoinAddress(address).Get()))
+        wallet->SetAddressBookName(CBitcoinAddress(address).Get(), label);
+}
+
+void MultisigDialog::clear()
+{
+    while(ui->pubkeyEntries->count())
+        delete ui->pubkeyEntries->takeAt(0)->widget();
+
+    addPubKey();
+    addPubKey();
+    updateRemoveEnabled();
+}
+
+MultisigAddressEntry * MultisigDialog::addPubKey()
+{
+    MultisigAddressEntry *entry = new MultisigAddressEntry(this);
+
+    entry->setModel(model);
+    ui->pubkeyEntries->addWidget(entry);
+    connect(entry, SIGNAL(removeEntry(MultisigAddressEntry *)), this, SLOT(removeEntry(MultisigAddressEntry *)));
+    updateRemoveEnabled();
+    entry->clear();
+    ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
+    QScrollBar *bar = ui->scrollArea->verticalScrollBar();
+    if(bar)
+        bar->setSliderPosition(bar->maximum());
+
+    return entry;
+}
+
+void MultisigDialog::removeEntry(MultisigAddressEntry *entry)
+{
+    delete entry;
+    updateRemoveEnabled();
+}
+
+void MultisigDialog::on_createTransactionButton_clicked()
+{
+    CTransaction transaction;
+
+    // Get inputs
+    for(int i = 0; i < ui->inputs->count(); i++)
+    {
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(i)->widget());
+        if(entry)
+        {
+            if(entry->validate())
+            {
+                CTxIn input = entry->getInput();
+                transaction.vin.push_back(input);
+            }
+            else
+                return;
+        }
+    }
+
+    // Get outputs
+    for(int i = 0; i < ui->outputs->count(); i++)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->outputs->itemAt(i)->widget());
+
+        if(entry)
+        {
+            if(entry->validate())
+            {
+                SendCoinsRecipient recipient = entry->getValue();
+                CBitcoinAddress address(recipient.address.toStdString());
+                CScript scriptPubKey;
+                scriptPubKey.SetDestination(address.Get());
+                int64 amount = recipient.amount;
+                CTxOut output(amount, scriptPubKey);
+                transaction.vout.push_back(output);
+            }
+            else
+                return;
+        }
+    }
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << transaction;
+    ui->transaction->setText(HexStr(ss.begin(), ss.end()).c_str());
+}
+
+void MultisigDialog::on_transaction_textChanged()
+{
+    while(ui->inputs->count())
+        delete ui->inputs->takeAt(0)->widget();
+    while(ui->outputs->count())
+        delete ui->outputs->takeAt(0)->widget();
+
+    if(ui->transaction->text().size() > 0)
+        ui->signTransactionButton->setEnabled(true);
+    else
+        ui->signTransactionButton->setEnabled(false);
+
+    // Decode the raw transaction
+    std::vector<unsigned char> txData(ParseHex(ui->transaction->text().toStdString()));
+    CDataStream ss(txData, SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    try
+    {
+        ss >> tx;
+    }
+    catch(std::exception &e)
+    {
+        return;
+    }
+
+    // Fill input list
+    int index = -1;
+    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    {
+        uint256 prevoutHash = txin.prevout.hash;
+        addInput();
+        index++;
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(index)->widget());
+        if(entry)
+        {
+            entry->setTransactionId(QString(prevoutHash.GetHex().c_str()));
+            entry->setTransactionOutputIndex(txin.prevout.n);
+        }
+    }
+
+    // Fill output list
+    index = -1;
+    BOOST_FOREACH(const CTxOut& txout, tx.vout)
+    {
+        CScript scriptPubKey = txout.scriptPubKey;
+        CTxDestination addr;
+        ExtractDestination(scriptPubKey, addr);
+        CBitcoinAddress address(addr);
+        SendCoinsRecipient recipient;
+        recipient.address = QString(address.ToString().c_str());
+        recipient.amount = txout.nValue;
+        addOutput();
+        index++;
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->outputs->itemAt(index)->widget());
+        if(entry)
+        {
+            entry->setValue(recipient);
+        }
+    }
+
+    updateRemoveEnabled();
+}
+
+void MultisigDialog::on_copyTransactionButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->transaction->text());
+}
+
+void MultisigDialog::on_pasteTransactionButton_clicked()
+{
+    ui->transaction->setText(QApplication::clipboard()->text());
+}
+
+void MultisigDialog::on_signTransactionButton_clicked()
+{
+    ui->signedTransaction->clear();
+
+    if(!model)
+        return;
+
+    CWallet *wallet = model->getWallet();
+
+    // Decode the raw transaction
+    std::vector<unsigned char> txData(ParseHex(ui->transaction->text().toStdString()));
+    CDataStream ss(txData, SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    try
+    {
+        ss >> tx;
+    }
+    catch(std::exception &e)
+    {
+        return;
+    }
+    CTransaction mergedTx(tx);
+
+    // Fetch previous transactions (inputs)
+    std::map<COutPoint, CScript> mapPrevOut;
+    for(int i = 0; i < mergedTx.vin.size(); i++)
+    {
+        CTransaction tempTx;
+        MapPrevTx mapPrevTx;
+        CTxDB txdb("r");
+        std::map<uint256, CTxIndex> unused;
+        bool fInvalid;
+
+        tempTx.vin.push_back(mergedTx.vin[i]);
+        tempTx.FetchInputs(txdb, unused, false, false, mapPrevTx, fInvalid);
+
+        BOOST_FOREACH(const CTxIn& txin, tempTx.vin)
+        {
+            const uint256& prevHash = txin.prevout.hash;
+            if(mapPrevTx.count(prevHash) && mapPrevTx[prevHash].second.vout.size() > txin.prevout.n)
+                mapPrevOut[txin.prevout] = mapPrevTx[prevHash].second.vout[txin.prevout.n].scriptPubKey;
+        }
+    }
+
+    // Add the redeem scripts to the wallet keystore
+    for(int i = 0; i < ui->inputs->count(); i++)
+    {
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(i)->widget());
+        if(entry)
+        {
+            QString redeemScriptStr = entry->getRedeemScript();
+            if(redeemScriptStr.size() > 0)
+            {
+                std::vector<unsigned char> scriptData(ParseHex(redeemScriptStr.toStdString()));
+                CScript redeemScript(scriptData.begin(), scriptData.end());
+                wallet->AddCScript(redeemScript);
+            }
+        }
+    }
+
+    WalletModel::UnlockContext ctx(model->requestUnlock());
+    if(!ctx.isValid())
+        return;
+
+    // Sign what we can
+    bool fComplete = true;
+    for(int i = 0; i < mergedTx.vin.size(); i++)
+    {
+        CTxIn& txin = mergedTx.vin[i];
+        if(mapPrevOut.count(txin.prevout) == 0)
+        {
+            fComplete = false;
+            continue;
+        }
+        const CScript& prevPubKey = mapPrevOut[txin.prevout];
+
+        txin.scriptSig.clear();
+        SignSignature(*wallet, prevPubKey, mergedTx, i, SIGHASH_ALL);
+        txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, tx.vin[i].scriptSig);
+        if(!VerifyScript(txin.scriptSig, prevPubKey, mergedTx, i, true, 0))
+        {
+          fComplete = false;
+        }
+    }
+
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << mergedTx;
+    ui->signedTransaction->setText(HexStr(ssTx.begin(), ssTx.end()).c_str());
+
+    if(fComplete)
+    {
+        ui->statusLabel->setText(tr("Transaction signature is complete"));
+        ui->sendTransactionButton->setEnabled(true);
+    }
+    else
+    {
+        ui->statusLabel->setText(tr("Transaction is NOT completely signed"));
+        ui->sendTransactionButton->setEnabled(false);
+    }
+}
+
+void MultisigDialog::on_copySignedTransactionButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->signedTransaction->text());
+}
+
+void MultisigDialog::on_sendTransactionButton_clicked()
+{
+    int64 transactionSize = ui->signedTransaction->text().size() / 2;
+    if(transactionSize == 0)
+        return;
+
+    // Check the fee
+    int64 fee = (int64 ) (ui->fee->text().toDouble() * COIN);
+    int64 minFee = MIN_TX_FEE * (1 + (int64) transactionSize / 1000);
+    if(fee < minFee)
+    {
+        QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Confirm send transaction"), tr("The fee of the transaction (%1 PPC) is smaller than the expected fee (%2 PPC). Do you want to send the transaction anyway?").arg((double) fee / COIN).arg((double) minFee / COIN), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+        if(ret != QMessageBox::Yes)
+            return;
+    }
+    else if(fee > minFee)
+    {
+        QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Confirm send transaction"), tr("The fee of the transaction (%1 PPC) is bigger than the expected fee (%2 PPC). Do you want to send the transaction anyway?").arg((double) fee / COIN).arg((double) minFee / COIN), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+        if(ret != QMessageBox::Yes)
+            return;
+    }
+
+    // Decode the raw transaction
+    std::vector<unsigned char> txData(ParseHex(ui->signedTransaction->text().toStdString()));
+    CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    try
+    {
+        ssData >> tx;
+    }
+    catch(std::exception &e)
+    {
+        return;
+    }
+    uint256 txHash = tx.GetHash();
+
+    // Check if the transaction is already in the blockchain
+    CTransaction existingTx;
+    uint256 blockHash = 0;
+    if(GetTransaction(txHash, existingTx, blockHash))
+    {
+        if(blockHash != 0)
+            return;
+    }
+
+    // Send the transaction to the local node
+    CTxDB txdb("r");
+    if(!tx.AcceptToMemoryPool(txdb, false))
+        return;
+    SyncWithWallets(tx, NULL, true);
+    RelayMessage(CInv(MSG_TX, txHash), tx);
+}
+
+MultisigInputEntry * MultisigDialog::addInput()
+{
+    MultisigInputEntry *entry = new MultisigInputEntry(this);
+
+    entry->setModel(model);
+    ui->inputs->addWidget(entry);
+    connect(entry, SIGNAL(removeEntry(MultisigInputEntry *)), this, SLOT(removeEntry(MultisigInputEntry *)));
+    connect(entry, SIGNAL(updateAmount()), this, SLOT(updateAmounts()));
+    updateRemoveEnabled();
+    entry->clear();
+    ui->scrollAreaWidgetContents_2->resize(ui->scrollAreaWidgetContents_2->sizeHint());
+    QScrollBar *bar = ui->scrollArea_2->verticalScrollBar();
+    if(bar)
+        bar->setSliderPosition(bar->maximum());
+
+    return entry;
+}
+
+void MultisigDialog::removeEntry(MultisigInputEntry *entry)
+{
+    delete entry;
+    updateRemoveEnabled();
+}
+
+SendCoinsEntry * MultisigDialog::addOutput()
+{
+    SendCoinsEntry *entry = new SendCoinsEntry(this);
+
+    entry->setModel(model);
+    ui->outputs->addWidget(entry);
+    connect(entry, SIGNAL(removeEntry(SendCoinsEntry *)), this, SLOT(removeEntry(SendCoinsEntry *)));
+    connect(entry, SIGNAL(payAmountChanged()), this, SLOT(updateAmounts()));
+    updateRemoveEnabled();
+    entry->clear();
+    ui->scrollAreaWidgetContents_3->resize(ui->scrollAreaWidgetContents_3->sizeHint());
+    QScrollBar *bar = ui->scrollArea_3->verticalScrollBar();
+    if(bar)
+        bar->setSliderPosition(bar->maximum());
+
+    return entry;
+}
+
+void MultisigDialog::removeEntry(SendCoinsEntry *entry)
+{
+    delete entry;
+    updateRemoveEnabled();
+}
+
+void MultisigDialog::updateAmounts()
+{
+    // Update inputs amount
+    int64 inputsAmount = 0;
+    for(int i = 0; i < ui->inputs->count(); i++)
+    {
+        MultisigInputEntry *entry = qobject_cast<MultisigInputEntry *>(ui->inputs->itemAt(i)->widget());
+        if(entry)
+            inputsAmount += entry->getAmount();
+    }
+    QString inputsAmountStr;
+    inputsAmountStr.sprintf("%.6f", (double) inputsAmount / COIN);
+    ui->inputsAmount->setText(inputsAmountStr);
+
+    // Update outputs amount
+    int64 outputsAmount = 0;
+    for(int i = 0; i < ui->outputs->count(); i++)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->outputs->itemAt(i)->widget());
+        if(entry)
+            outputsAmount += entry->getValue().amount;
+    }
+    QString outputsAmountStr;
+    outputsAmountStr.sprintf("%.6f", (double) outputsAmount / COIN);
+    ui->outputsAmount->setText(outputsAmountStr);
+
+    // Update Fee amount
+    int64 fee = inputsAmount - outputsAmount;
+    QString feeStr;
+    feeStr.sprintf("%.6f", (double) fee / COIN);
+    ui->fee->setText(feeStr);
+}

--- a/src/qt/multisigdialog.h
+++ b/src/qt/multisigdialog.h
@@ -1,0 +1,56 @@
+#ifndef MULTISIGDIALOG_H
+#define MULTISIGDIALOG_H
+
+#include <QDialog>
+
+#include "multisigaddressentry.h"
+#include "multisiginputentry.h"
+#include "sendcoinsentry.h"
+#include "walletmodel.h"
+
+
+namespace Ui
+{
+    class MultisigDialog;
+}
+
+class MultisigDialog : public QDialog
+{
+    Q_OBJECT;
+
+  public:
+    explicit MultisigDialog(QWidget *parent);
+    ~MultisigDialog();
+    void setModel(WalletModel *model);
+
+  public slots:
+    MultisigAddressEntry * addPubKey();
+    void clear();
+    void updateRemoveEnabled();
+    MultisigInputEntry * addInput();
+    SendCoinsEntry * addOutput();
+
+  private:
+    Ui::MultisigDialog *ui;
+    WalletModel *model;
+
+  private slots:
+    void on_createAddressButton_clicked();
+    void on_copyMultisigAddressButton_clicked();
+    void on_copyRedeemScriptButton_clicked();
+    void on_saveRedeemScriptButton_clicked();
+    void on_saveMultisigAddressButton_clicked();
+    void removeEntry(MultisigAddressEntry *entry);
+    void on_createTransactionButton_clicked();
+    void on_transaction_textChanged();
+    void on_copyTransactionButton_clicked();
+    void on_pasteTransactionButton_clicked();
+    void on_signTransactionButton_clicked();
+    void on_copySignedTransactionButton_clicked();
+    void on_sendTransactionButton_clicked();
+    void removeEntry(MultisigInputEntry *entry);
+    void removeEntry(SendCoinsEntry *entry);
+    void updateAmounts();
+};
+
+#endif // MULTISIGDIALOG_H

--- a/src/qt/multisiginputentry.cpp
+++ b/src/qt/multisiginputentry.cpp
@@ -1,0 +1,174 @@
+#include <QApplication>
+#include <QClipboard>
+#include <string>
+#include <vector>
+
+#include "base58.h"
+#include "multisiginputentry.h"
+#include "ui_multisiginputentry.h"
+#include "main.h"
+#include "script.h"
+#include "util.h"
+#include "wallet.h"
+#include "walletmodel.h"
+
+
+MultisigInputEntry::MultisigInputEntry(QWidget *parent) : QFrame(parent), ui(new Ui::MultisigInputEntry), model(0)
+{
+    ui->setupUi(this);
+}
+
+MultisigInputEntry::~MultisigInputEntry()
+{
+    delete ui;
+}
+
+void MultisigInputEntry::setModel(WalletModel *model)
+{
+    this->model = model;
+    clear();
+}
+
+void MultisigInputEntry::clear()
+{
+    ui->transactionId->clear();
+    ui->transactionOutput->clear();
+    ui->redeemScript->clear();
+}
+
+bool MultisigInputEntry::validate()
+{
+    return (ui->transactionOutput->count() > 0);
+}
+
+CTxIn MultisigInputEntry::getInput()
+{
+    int nOutput = ui->transactionOutput->currentIndex();
+    CTxIn input(COutPoint(txHash, nOutput));
+
+    return input;
+}
+
+int64 MultisigInputEntry::getAmount()
+{
+    int64 amount = 0;
+    int nOutput = ui->transactionOutput->currentIndex();
+    CTransaction tx;
+    uint256 blockHash = 0;
+
+    if(GetTransaction(txHash, tx, blockHash))
+    {
+        if(nOutput < tx.vout.size())
+        {
+            const CTxOut& txOut = tx.vout[nOutput];
+            amount = txOut.nValue;
+        }
+    }
+
+    return amount;
+}
+
+QString MultisigInputEntry::getRedeemScript()
+{
+    return ui->redeemScript->text();
+}
+
+void MultisigInputEntry::setTransactionId(QString transactionId)
+{
+    ui->transactionId->setText(transactionId);
+}
+
+void MultisigInputEntry::setTransactionOutputIndex(int index)
+{
+    ui->transactionOutput->setCurrentIndex(index);
+}
+
+void MultisigInputEntry::setRemoveEnabled(bool enabled)
+{
+    ui->deleteButton->setEnabled(enabled);
+}
+
+void MultisigInputEntry::on_pasteTransactionIdButton_clicked()
+{
+    ui->transactionId->setText(QApplication::clipboard()->text());
+}
+
+void MultisigInputEntry::on_deleteButton_clicked()
+{
+    emit removeEntry(this);
+}
+
+void MultisigInputEntry::on_pasteRedeemScriptButton_clicked()
+{
+    ui->redeemScript->setText(QApplication::clipboard()->text());
+}
+
+void MultisigInputEntry::on_transactionId_textChanged(const QString &transactionId)
+{
+    ui->transactionOutput->clear();
+    if(transactionId.isEmpty())
+        return;
+
+    // Make list of transaction outputs
+    txHash.SetHex(transactionId.toStdString().c_str());
+    CTransaction tx;
+    uint256 blockHash = 0;
+    if(!GetTransaction(txHash, tx, blockHash))
+        return;
+    for(int i = 0; i < tx.vout.size(); i++)
+    {
+        QString idStr;
+        idStr.setNum(i);
+        const CTxOut& txOut = tx.vout[i];
+        int64 amount = txOut.nValue;
+        QString amountStr;
+        amountStr.sprintf("%.6f", (double) amount / COIN);
+        CScript script = txOut.scriptPubKey;
+        CTxDestination addr;
+        if(ExtractDestination(script, addr))
+        {
+            CBitcoinAddress address(addr);
+            QString addressStr(address.ToString().c_str());
+            ui->transactionOutput->addItem(idStr + QString(" - ") + addressStr + QString(" - ") + amountStr + QString(" PPC"));
+        }
+        else
+            ui->transactionOutput->addItem(idStr + QString(" - ") + amountStr + QString(" PPC"));
+    }
+}
+
+void MultisigInputEntry::on_transactionOutput_currentIndexChanged(int index)
+{
+    if(ui->transactionOutput->itemText(index).isEmpty())
+        return;
+
+    CTransaction tx;
+    uint256 blockHash = 0;
+    if(!GetTransaction(txHash, tx, blockHash))
+        return;
+    const CTxOut& txOut = tx.vout[index];
+    CScript script = txOut.scriptPubKey;
+
+    if(script.IsPayToScriptHash())
+    {
+        ui->redeemScript->setEnabled(true);
+
+        if(model)
+        {
+            // Try to find the redeem script
+            CTxDestination dest;
+            if(ExtractDestination(script, dest))
+                {
+                    CScriptID scriptID = boost::get<CScriptID>(dest);
+                    CScript redeemScript;
+                    if(model->getWallet()->GetCScript(scriptID, redeemScript))
+                        ui->redeemScript->setText(HexStr(redeemScript.begin(), redeemScript.end()).c_str());
+                }
+        }
+    }
+    else
+    {
+        ui->redeemScript->setEnabled(false);
+    }
+
+    emit updateAmount();
+}

--- a/src/qt/multisiginputentry.h
+++ b/src/qt/multisiginputentry.h
@@ -1,0 +1,53 @@
+#ifndef MULTISIGINPUTENTRY_H
+#define MULTISIGINPUTENTRY_H
+
+#include <QFrame>
+
+#include "uint256.h"
+
+
+class CTxIn;
+class WalletModel;
+
+namespace Ui
+{
+    class MultisigInputEntry;
+}
+
+class MultisigInputEntry : public QFrame
+{
+    Q_OBJECT;
+
+  public:
+    explicit MultisigInputEntry(QWidget *parent = 0);
+    ~MultisigInputEntry();
+    void setModel(WalletModel *model);
+    bool validate();
+    CTxIn getInput();
+    int64 getAmount();
+    QString getRedeemScript();
+    void setTransactionId(QString transactionId);
+    void setTransactionOutputIndex(int index);
+
+  public slots:
+    void setRemoveEnabled(bool enabled);
+    void clear();
+
+  signals:
+    void removeEntry(MultisigInputEntry *entry);
+    void updateAmount();
+
+  private:
+    Ui::MultisigInputEntry *ui;
+    WalletModel *model;
+    uint256 txHash;
+
+  private slots:
+    void on_transactionId_textChanged(const QString &transactionId);
+    void on_pasteTransactionIdButton_clicked();
+    void on_deleteButton_clicked();
+    void on_transactionOutput_currentIndexChanged(int index);
+    void on_pasteRedeemScriptButton_clicked();
+};
+
+#endif // MULTISIGINPUTENTRY_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -251,6 +251,6 @@ bool TransactionRecord::statusUpdateNeeded()
 
 std::string TransactionRecord::getTxID()
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return hash.ToString(); // + strprintf("-%03d", idx);
 }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -125,6 +125,7 @@ TransactionView::TransactionView(QWidget *parent) :
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *copyTransactionIdAction = new QAction(tr("Copy transaction id"), this);
     QAction *editLabelAction = new QAction(tr("Edit label"), this);
     QAction *showDetailsAction = new QAction(tr("Show details..."), this);
     QAction *clearOrphansAction = new QAction(tr("Clear orphans"), this);
@@ -133,6 +134,7 @@ TransactionView::TransactionView(QWidget *parent) :
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);
+    contextMenu->addAction(copyTransactionIdAction);
     contextMenu->addAction(editLabelAction);
     contextMenu->addAction(showDetailsAction);
     contextMenu->addSeparator();
@@ -150,6 +152,7 @@ TransactionView::TransactionView(QWidget *parent) :
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
+    connect(copyTransactionIdAction, SIGNAL(triggered()), this, SLOT(copyTransactionId()));
     connect(editLabelAction, SIGNAL(triggered()), this, SLOT(editLabel()));
     connect(showDetailsAction, SIGNAL(triggered()), this, SLOT(showDetails()));
     connect(clearOrphansAction, SIGNAL(triggered()), this, SLOT(clearOrphans()));
@@ -316,6 +319,11 @@ void TransactionView::copyLabel()
 void TransactionView::copyAmount()
 {
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::FormattedAmountRole);
+}
+
+void TransactionView::copyTransactionId()
+{
+    GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::TxIDRole);
 }
 
 void TransactionView::editLabel()

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -65,6 +65,7 @@ private slots:
     void editLabel();
     void copyLabel();
     void copyAmount();
+    void copyTransactionId();
     void clearOrphans();
 
 signals:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -388,3 +388,8 @@ void WalletModel::clearOrphans()
 {
     wallet->ClearOrphans();
 }
+
+CWallet * WalletModel::getWallet()
+{
+    return wallet;
+}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -124,6 +124,7 @@ public:
     void listLockedCoins(std::vector<COutPoint>& vOutpts); 
 
     void clearOrphans();
+    CWallet * getWallet();
 
 private:
     CWallet *wallet;


### PR DESCRIPTION
This is a new dialog (accessible through an entry in the 'File' menu) allowing basic operations with multisig addresses (more easily than with the RPC system):
- creating a multisig address
- creating a new raw transaction (e.g. to spend the funds of a multisig address)
- signing a raw transaction
- sending a raw transaction to the network

I made some simple tests and it seems to work fine, but there are probably a few bugs still in there, so more testing will be necessary.

Also, I didn't spend too much time on the look and feel of the dialog, so there's room for improvement...
