### PR TITLE
Add TheSeven's dnsseed

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1141,6 +1141,7 @@ void MapPort(bool /* unused fMapPort */)
 static const char *strDNSSeed[][2] = {
     {"seed", "seed.ppcoin.net"},
     {"seedppc", "seedppc.ppcoin.net"},
+    {"7server", "ppcseed.ns.7server.net"},
     {"altcointech", "dnsseed.ppc.altcointech.net"},
     {"tnseed", "tnseed.ppcoin.net"},
     {"tnseedppc", "tnseedppc.ppcoin.net"},


### PR DESCRIPTION
TheSeven has kindly provided an auto dns seed service for peercoin. This change adds TheSeven's dnsseed to the dnsseed list.