### PR TITLE
Add Diandianbi.org's dnsseed

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2012 The Bitcoin developers
-// Copyright (c) 2011-2013 The PPCoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2009-2012 The Bitcoin Core developers
+// Copyright (c) 2011-2015 The Peercoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "irc.h"
@@ -1142,6 +1142,7 @@ static const char *strDNSSeed[][2] = {
     {"seed", "seed.ppcoin.net"},
     {"seedppc", "seedppc.ppcoin.net"},
     {"altcointech", "dnsseed.ppc.altcointech.net"},
+    {"diandianbi", "seed.diandianbi.org"},
     {"tnseed", "tnseed.ppcoin.net"},
     {"tnseedppc", "tnseedppc.ppcoin.net"},
 };

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1141,6 +1141,7 @@ void MapPort(bool /* unused fMapPort */)
 static const char *strDNSSeed[][2] = {
     {"seed", "seed.ppcoin.net"},
     {"seedppc", "seedppc.ppcoin.net"},
+    {"7server", "ppcseed.ns.7server.net"},
     {"altcointech", "dnsseed.ppc.altcointech.net"},
     {"diandianbi", "seed.diandianbi.org"},
     {"tnseed", "tnseed.ppcoin.net"},


### PR DESCRIPTION
Diandianbi.org have kindly provided an auto dns seed service for peercoin. This change adds Diandianbi.org's dnsseed to the dnsseed list.

https://www.peercointalk.org/index.php?topic=4074.0