### PR TITLE
Fix gitian-builder compilation

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -11,10 +11,10 @@ SetCompressor /SOLID lzma
 
 # MUI Symbol Definitions
 !define MUI_ICON "../share/pixmaps/peerunity.ico"
-!define MUI_WELCOMEFINISHPAGE_BITMAP "../share/pixmaps/nsis-wizard.bmp"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "../share/pixmaps/peerunity128.png"
 !define MUI_HEADERIMAGE
 !define MUI_HEADERIMAGE_RIGHT
-!define MUI_HEADERIMAGE_BITMAP "../share/pixmaps/nsis-header.bmp"
+!define MUI_HEADERIMAGE_BITMAP "../share/pixmaps/peerunity64.png"
 !define MUI_FINISHPAGE_NOAUTOCLOSE
 !define MUI_STARTMENUPAGE_REGISTRY_ROOT HKLM
 !define MUI_STARTMENUPAGE_REGISTRY_KEY ${REGKEY}
@@ -22,7 +22,7 @@ SetCompressor /SOLID lzma
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER Peerunity
 !define MUI_FINISHPAGE_RUN $INSTDIR\Peerunity.exe
 !define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
-!define MUI_UNWELCOMEFINISHPAGE_BITMAP "../share/pixmaps/nsis-wizard.bmp"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP "../share/pixmaps/peerunity128.png"
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
 
 # Included files

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -32,7 +32,7 @@ signals:
     void transactionClicked(const QModelIndex &index);
 
 protected:
-    void resizeEvent(QResizeEvent *event) override;
+    void resizeEvent(QResizeEvent *event);
 
 private:
     Ui::OverviewPage *ui;


### PR DESCRIPTION
One of the headers has an 'override' which is not understood by the gcc version in the gitian virtual machine used to generate the binaries. Therefore the binaries generation fails.

Removing the 'override' fixes the problem.