### PR TITLE
Peerunity unit test fixes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1016,10 +1016,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -16,17 +16,17 @@ BOOST_AUTO_TEST_CASE(sanity)
 {
     uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
     uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
-    BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
-    BOOST_CHECK(Checkpoints::CheckBlock(134444, p134444));
+    BOOST_CHECK(Checkpoints::CheckHardened(11111, p11111));
+    BOOST_CHECK(Checkpoints::CheckHardened(134444, p134444));
 
     
     // Wrong hashes at checkpoints should fail:
-    BOOST_CHECK(!Checkpoints::CheckBlock(11111, p134444));
-    BOOST_CHECK(!Checkpoints::CheckBlock(134444, p11111));
+    BOOST_CHECK(!Checkpoints::CheckHardened(11111, p134444));
+    BOOST_CHECK(!Checkpoints::CheckHardened(134444, p11111));
 
     // ... but any hash not at a checkpoint should succeed:
-    BOOST_CHECK(Checkpoints::CheckBlock(11111+1, p134444));
-    BOOST_CHECK(Checkpoints::CheckBlock(134444+1, p11111));
+    BOOST_CHECK(Checkpoints::CheckHardened(11111+1, p134444));
+    BOOST_CHECK(Checkpoints::CheckHardened(134444+1, p11111));
 
     BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 134444);
 }    

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -14,21 +14,21 @@ BOOST_AUTO_TEST_SUITE(Checkpoints_tests)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {
-    uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
-    uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
-    BOOST_CHECK(Checkpoints::CheckHardened(11111, p11111));
-    BOOST_CHECK(Checkpoints::CheckHardened(134444, p134444));
+    uint256 p19080 = uint256("0x000000000000bca54d9ac17881f94193fd6a270c1bb21c3bf0b37f588a40dbd7");
+    uint256 p99999 = uint256("0x27fd5e1de16a4270eb8c68dee2754a64da6312c7c3a0e99a7e6776246be1ee3f");
+    BOOST_CHECK(Checkpoints::CheckHardened(19080, p19080));
+    BOOST_CHECK(Checkpoints::CheckHardened(99999, p99999));
 
     
     // Wrong hashes at checkpoints should fail:
-    BOOST_CHECK(!Checkpoints::CheckHardened(11111, p134444));
-    BOOST_CHECK(!Checkpoints::CheckHardened(134444, p11111));
+    BOOST_CHECK(!Checkpoints::CheckHardened(19080, p99999));
+    BOOST_CHECK(!Checkpoints::CheckHardened(99999, p19080));
 
     // ... but any hash not at a checkpoint should succeed:
-    BOOST_CHECK(Checkpoints::CheckHardened(11111+1, p134444));
-    BOOST_CHECK(Checkpoints::CheckHardened(134444+1, p11111));
+    BOOST_CHECK(Checkpoints::CheckHardened(19080+1, p99999));
+    BOOST_CHECK(Checkpoints::CheckHardened(99999+1, p19080));
 
-    BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 134444);
-}    
+    BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 99999);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -10,14 +10,14 @@
 
 using namespace std;
 
-static const string strSecret1     ("5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj");
-static const string strSecret2     ("5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3");
-static const string strSecret1C    ("Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw");
-static const string strSecret2C    ("L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g");
-static const CBitcoinAddress addr1 ("1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ");
-static const CBitcoinAddress addr2 ("1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ");
-static const CBitcoinAddress addr1C("1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs");
-static const CBitcoinAddress addr2C("1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs");
+static const string strSecret1     ("7AChr8cfXUxKJCpjekqEQGoRgpN1iFw44egp4jtqzmX8xTdtsiy");
+static const string strSecret2     ("79kbfhqh1HV1B8ZxnsbSnu2F9jbm7XryrNBgvSKusoTpeppWmZr");
+static const string strSecret1C    ("UBcfHrcR3YP9kwBhFeTt9ijuxk3k96uaX7LijWKqFyW27MPrVSuX");
+static const string strSecret2C    ("U9dS1qFuaFkbmiQVFUK2qacVTZ2RhqDbvtWBCrnUPE5PKkLweTka");
+static const CBitcoinAddress addr1 ("PKkaDEczLygWFN1C3ccEGraLshKMMEoBgn");
+static const CBitcoinAddress addr2 ("PXYTm8BcoygtXB7VrAn77DeXhXCNSxxwsW");
+static const CBitcoinAddress addr1C("PJC1cL5mBMKmQ357ZNMDVAWH5sDVJNX3p8");
+static const CBitcoinAddress addr2C("P95CZ3kFgAvjnMdRgqLoApDuQ49ir7VAP7");
 
 
 static const string strAddressBad("1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF");

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -145,19 +145,19 @@ BOOST_AUTO_TEST_CASE(set)
     // Test the CScript::Set* methods
     CBasicKeyStore keystore;
     CKey key[4];
-    std::vector<CKey> keys;
+    std::vector<CPubKey> keys;
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
         keystore.AddKey(key[i]);
-        keys.push_back(key[i]);
+        keys.push_back(key[i].GetPubKey());
     }
 
     CScript inner[4];
     inner[0].SetDestination(key[0].GetPubKey().GetID());
-    inner[1].SetMultisig(2, std::vector<CKey>(keys.begin(), keys.begin()+2));
-    inner[2].SetMultisig(1, std::vector<CKey>(keys.begin(), keys.begin()+2));
-    inner[3].SetMultisig(2, std::vector<CKey>(keys.begin(), keys.begin()+3));
+    inner[1].SetMultisig(2, std::vector<CPubKey>(keys.begin(), keys.begin()+2));
+    inner[2].SetMultisig(1, std::vector<CPubKey>(keys.begin(), keys.begin()+2));
+    inner[3].SetMultisig(2, std::vector<CPubKey>(keys.begin(), keys.begin()+3));
 
     CScript outer[4];
     for (int i = 0; i < 4; i++)
@@ -246,12 +246,12 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     std::map<uint256, std::pair<CTxIndex, CTransaction> > mapInputs;
     CBasicKeyStore keystore;
     CKey key[3];
-    vector<CKey> keys;
+    vector<CPubKey> keys;
     for (int i = 0; i < 3; i++)
     {
         key[i].MakeNewKey(true);
         keystore.AddKey(key[i]);
-        keys.push_back(key[i]);
+        keys.push_back(key[i].GetPubKey());
     }
 
     CTransaction txFrom;

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -37,12 +37,12 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     scriptSig << OP_0 << Serialize(s1);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3);
 
-    std::vector<CKey> keys;
+    std::vector<CPubKey> keys;
     for (int i = 0; i < 3; i++)
     {
         CKey k;
         k.MakeNewKey(true);
-        keys.push_back(k);
+        keys.push_back(k.GetPubKey());
     }
     CScript s2;
     s2.SetMultisig(1, keys);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -9,7 +9,7 @@ CWallet* pwalletMain;
 extern bool fPrintToConsole;
 struct TestingSetup {
     TestingSetup() {
-        fPrintToConsole = true; // don't want to write to debug.log file
+        fPrintToDebugger = true; // don't want to write to debug.log file
         pwalletMain = new CWallet();
         RegisterWallet(pwalletMain);
     }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -150,21 +150,21 @@ BOOST_AUTO_TEST_CASE(test_GetThrow)
 
     MapPrevTx missingInputs;
 
-    CTransaction t;
-    t.vin.resize(3);
-    t.vin[0].prevout.hash = dummyTransactions[0].GetHash();
-    t.vin[0].prevout.n = 0;
-    t.vin[1].prevout.hash = dummyTransactions[1].GetHash();
-    t.vin[1].prevout.n = 0;
-    t.vin[2].prevout.hash = dummyTransactions[1].GetHash();
-    t.vin[2].prevout.n = 1;
-    t.vout.resize(2);
-    t.vout[0].nValue = 90*CENT;
-    t.vout[0].scriptPubKey << OP_1;
+    CTransaction t1;
+    t1.vin.resize(3);
+    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    t1.vin[0].prevout.n = 0;
+    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[1].prevout.n = 0;
+    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[2].prevout.n = 1;
+    t1.vout.resize(2);
+    t1.vout[0].nValue = 90*CENT;
+    t1.vout[0].scriptPubKey << OP_1;
 
-    t.vout[0].scriptPubKey = CScript() << OP_1;
-    BOOST_CHECK_THROW(t.AreInputsStandard(missingInputs), runtime_error);
-    BOOST_CHECK_THROW(t.GetValueIn(missingInputs), runtime_error);
+    t1.vout[0].scriptPubKey = CScript() << OP_1;
+    BOOST_CHECK_THROW(t1.AreInputsStandard(missingInputs), runtime_error);
+    BOOST_CHECK_THROW(t1.GetValueIn(missingInputs), runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -154,9 +154,9 @@ BOOST_AUTO_TEST_CASE(test_GetThrow)
     t.vin.resize(3);
     t.vin[0].prevout.hash = dummyTransactions[0].GetHash();
     t.vin[0].prevout.n = 0;
-    t.vin[1].prevout.hash = dummyTransactions[1].GetHash();;
+    t.vin[1].prevout.hash = dummyTransactions[1].GetHash();
     t.vin[1].prevout.n = 0;
-    t.vin[2].prevout.hash = dummyTransactions[1].GetHash();;
+    t.vin[2].prevout.hash = dummyTransactions[1].GetHash();
     t.vin[2].prevout.n = 1;
     t.vout.resize(2);
     t.vout[0].nValue = 90*CENT;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -9,8 +9,8 @@ BOOST_AUTO_TEST_SUITE(transaction_tests)
 
 BOOST_AUTO_TEST_CASE(basic_transaction_tests)
 {
-    // Random real transaction (e2769b09e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436)
-    unsigned char ch[] = {0x01, 0x00, 0x00, 0x00, 0x01, 0x6b, 0xff, 0x7f, 0xcd, 0x4f, 0x85, 0x65, 0xef, 0x40, 0x6d, 0xd5, 0xd6, 0x3d, 0x4f, 0xf9, 0x4f, 0x31, 0x8f, 0xe8, 0x20, 0x27, 0xfd, 0x4d, 0xc4, 0x51, 0xb0, 0x44, 0x74, 0x01, 0x9f, 0x74, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x8c, 0x49, 0x30, 0x46, 0x02, 0x21, 0x00, 0xda, 0x0d, 0xc6, 0xae, 0xce, 0xfe, 0x1e, 0x06, 0xef, 0xdf, 0x05, 0x77, 0x37, 0x57, 0xde, 0xb1, 0x68, 0x82, 0x09, 0x30, 0xe3, 0xb0, 0xd0, 0x3f, 0x46, 0xf5, 0xfc, 0xf1, 0x50, 0xbf, 0x99, 0x0c, 0x02, 0x21, 0x00, 0xd2, 0x5b, 0x5c, 0x87, 0x04, 0x00, 0x76, 0xe4, 0xf2, 0x53, 0xf8, 0x26, 0x2e, 0x76, 0x3e, 0x2d, 0xd5, 0x1e, 0x7f, 0xf0, 0xbe, 0x15, 0x77, 0x27, 0xc4, 0xbc, 0x42, 0x80, 0x7f, 0x17, 0xbd, 0x39, 0x01, 0x41, 0x04, 0xe6, 0xc2, 0x6e, 0xf6, 0x7d, 0xc6, 0x10, 0xd2, 0xcd, 0x19, 0x24, 0x84, 0x78, 0x9a, 0x6c, 0xf9, 0xae, 0xa9, 0x93, 0x0b, 0x94, 0x4b, 0x7e, 0x2d, 0xb5, 0x34, 0x2b, 0x9d, 0x9e, 0x5b, 0x9f, 0xf7, 0x9a, 0xff, 0x9a, 0x2e, 0xe1, 0x97, 0x8d, 0xd7, 0xfd, 0x01, 0xdf, 0xc5, 0x22, 0xee, 0x02, 0x28, 0x3d, 0x3b, 0x06, 0xa9, 0xd0, 0x3a, 0xcf, 0x80, 0x96, 0x96, 0x8d, 0x7d, 0xbb, 0x0f, 0x91, 0x78, 0xff, 0xff, 0xff, 0xff, 0x02, 0x8b, 0xa7, 0x94, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xba, 0xde, 0xec, 0xfd, 0xef, 0x05, 0x07, 0x24, 0x7f, 0xc8, 0xf7, 0x42, 0x41, 0xd7, 0x3b, 0xc0, 0x39, 0x97, 0x2d, 0x7b, 0x88, 0xac, 0x40, 0x94, 0xa8, 0x02, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xc1, 0x09, 0x32, 0x48, 0x3f, 0xec, 0x93, 0xed, 0x51, 0xf5, 0xfe, 0x95, 0xe7, 0x25, 0x59, 0xf2, 0xcc, 0x70, 0x43, 0xf9, 0x88, 0xac, 0x00, 0x00, 0x00, 0x00, 0x00};
+    // Random real transaction (0aad88ccf4a93e6e0c51a4b2c735b72b049a1b0d078dbe033a3ef0e9536483d3)
+    unsigned char ch[] = {1, 0, 0, 0, 199, 164, 233, 86, 2, 171, 88, 83, 94, 35, 232, 126, 67, 179, 60, 10, 33, 147, 214, 124, 159, 158, 168, 5, 176, 215, 131, 102, 144, 176, 62, 55, 234, 104, 131, 227, 50, 0, 0, 0, 0, 106, 71, 48, 68, 2, 32, 88, 154, 50, 124, 193, 82, 175, 93, 51, 97, 189, 152, 199, 127, 180, 209, 71, 49, 47, 127, 50, 198, 163, 180, 64, 191, 246, 174, 84, 5, 212, 215, 2, 32, 18, 33, 141, 93, 247, 182, 40, 158, 113, 103, 131, 179, 96, 254, 95, 0, 216, 45, 248, 190, 253, 163, 66, 216, 74, 144, 254, 145, 223, 34, 197, 175, 1, 33, 3, 44, 11, 40, 58, 0, 195, 137, 189, 135, 164, 112, 10, 218, 234, 79, 108, 142, 191, 128, 216, 61, 169, 146, 235, 252, 42, 140, 235, 149, 30, 60, 123, 255, 255, 255, 255, 229, 149, 206, 86, 116, 48, 226, 74, 58, 240, 243, 222, 116, 172, 234, 175, 208, 114, 244, 83, 185, 107, 168, 161, 52, 212, 91, 57, 201, 238, 196, 79, 0, 0, 0, 0, 106, 71, 48, 68, 2, 32, 56, 191, 119, 175, 41, 39, 97, 9, 15, 84, 12, 14, 99, 15, 205, 67, 120, 159, 187, 33, 80, 201, 104, 81, 19, 136, 230, 248, 187, 124, 104, 188, 2, 32, 96, 31, 40, 246, 36, 40, 39, 65, 151, 172, 231, 201, 14, 12, 99, 74, 73, 37, 1, 92, 58, 192, 253, 14, 250, 249, 245, 11, 226, 232, 204, 137, 1, 33, 3, 246, 76, 253, 20, 111, 183, 124, 112, 238, 11, 28, 102, 137, 133, 107, 97, 47, 69, 144, 217, 121, 33, 38, 128, 210, 2, 43, 187, 217, 129, 245, 157, 255, 255, 255, 255, 1, 64, 167, 144, 0, 0, 0, 0, 0, 25, 118, 169, 20, 65, 1, 103, 158, 39, 245, 201, 210, 142, 205, 250, 28, 169, 18, 134, 215, 5, 108, 237, 91, 136, 172, 0, 0, 0, 0, 0, 0};
     vector<unsigned char> vch(ch, ch + sizeof(ch) -1);
     CDataStream stream(vch, SER_DISK, CLIENT_VERSION);
     CTransaction tx;
@@ -93,28 +93,26 @@ BOOST_AUTO_TEST_CASE(test_Get)
     BOOST_CHECK(!t1.AreInputsStandard(dummyInputs));
 }
 
-BOOST_AUTO_TEST_CASE(test_GetThrow)
+BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
     CBasicKeyStore keystore;
     MapPrevTx dummyInputs;
     std::vector<CTransaction> dummyTransactions = SetupDummyInputs(keystore, dummyInputs);
 
-    MapPrevTx missingInputs;
-
-    CTransaction t1;
-    t1.vin.resize(3);
-    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
-    t1.vin[0].prevout.n = 0;
-    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();;
-    t1.vin[1].prevout.n = 0;
-    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();;
-    t1.vin[2].prevout.n = 1;
-    t1.vout.resize(2);
-    t1.vout[0].nValue = 90*CENT;
-    t1.vout[0].scriptPubKey << OP_1;
+    CTransaction t;
+    t.vin.resize(1);
+    t.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    t.vin[0].prevout.n = 1;
+    t.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
+    t.vout.resize(1);
+    t.vout[0].nValue = 90*CENT;
+    CKey key;
+    key.MakeNewKey(true);
+    t.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
+    BOOST_CHECK(t.IsStandard());
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
-    BOOST_CHECK(t.IsStandard());
+    BOOST_CHECK(!t.IsStandard());
 
     // 80-byte TX_NULL_DATA (standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
@@ -142,6 +140,31 @@ BOOST_AUTO_TEST_CASE(test_GetThrow)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!t.IsStandard());
+}
+
+BOOST_AUTO_TEST_CASE(test_GetThrow)
+{
+    CBasicKeyStore keystore;
+    MapPrevTx dummyInputs;
+    std::vector<CTransaction> dummyTransactions = SetupDummyInputs(keystore, dummyInputs);
+
+    MapPrevTx missingInputs;
+
+    CTransaction t;
+    t.vin.resize(3);
+    t.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    t.vin[0].prevout.n = 0;
+    t.vin[1].prevout.hash = dummyTransactions[1].GetHash();;
+    t.vin[1].prevout.n = 0;
+    t.vin[2].prevout.hash = dummyTransactions[1].GetHash();;
+    t.vin[2].prevout.n = 1;
+    t.vout.resize(2);
+    t.vout[0].nValue = 90*CENT;
+    t.vout[0].scriptPubKey << OP_1;
+
+    t.vout[0].scriptPubKey = CScript() << OP_1;
+    BOOST_CHECK_THROW(t.AreInputsStandard(missingInputs), runtime_error);
+    BOOST_CHECK_THROW(t.GetValueIn(missingInputs), runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -192,8 +192,10 @@ BOOST_AUTO_TEST_CASE(util_FormatMoney)
     BOOST_CHECK_EQUAL(FormatMoney(COIN/10000, false), "0.0001");
     BOOST_CHECK_EQUAL(FormatMoney(COIN/100000, false), "0.00001");
     BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000, false), "0.000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000, false), "0.0000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000, false), "0.00000001");
+
+// ppcoin: COIN = 1000000, cannot format money smaller than one satoshi
+    BOOST_CHECK_NE(FormatMoney(COIN/10000000, false), "0.0000001");
+    BOOST_CHECK_NE(FormatMoney(COIN/100000000, false), "0.00000001");
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseMoney)
@@ -235,10 +237,10 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK_EQUAL(ret, COIN/100000);
     BOOST_CHECK(ParseMoney("0.000001", ret));
     BOOST_CHECK_EQUAL(ret, COIN/1000000);
-    BOOST_CHECK(ParseMoney("0.0000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/10000000);
-    BOOST_CHECK(ParseMoney("0.00000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/100000000);
+
+// ppcoin: COIN = 1000000, cannot parse money smaller than one satoshi
+    BOOST_CHECK(!ParseMoney("0.0000001", ret));
+    BOOST_CHECK(!ParseMoney("0.00000001", ret));
 
     // Attempted 63 bit overflow should fail
     BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -207,7 +207,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         ret = vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
     }
-    else
+    else if (!fPrintToDebugger)
     {
         // print to debug.log
         if (!fileout)


### PR DESCRIPTION
I merged the ppcoin unit test fixes into the Peerunity code.

Please note that the files script_P2SH_tests.cpp & sigopcount_tests.cpp are different from ppcoin.
This is due to the difference in script.h between Peerunity and ppcoin:

```
-    void SetMultisig(int nRequired, const std::vector<CKey>& keys);
+    void SetMultisig(int nRequired, const std::vector<CPubKey>& keys);
```


All tests are now compiling and completing successfully.
